### PR TITLE
Implement alpha-blended selection bar

### DIFF
--- a/menu/menu.cpp
+++ b/menu/menu.cpp
@@ -177,7 +177,8 @@ void PrintTitle(const char *title)
 
 void PrintBar(u32 givenY)
 {
-	sal_ImageDraw(mHighLightBar,HIGHLIGHT_BAR_WIDTH, HIGHLIGHT_BAR_HEIGHT,0,givenY);
+	//sal_ImageDraw(mHighLightBar,HIGHLIGHT_BAR_WIDTH, HIGHLIGHT_BAR_HEIGHT,0,givenY);
+	sal_HighlightBar( 262, HIGHLIGHT_BAR_HEIGHT, 0, givenY);
 }
 
 void freeRomLists()

--- a/sal/include/sal_common.h
+++ b/sal/include/sal_common.h
@@ -126,5 +126,6 @@ s32 sal_DirectoryRead(struct SAL_DIR *d, struct SAL_DIRECTORY_ENTRY *dir);
 s32 sal_ImageLoad(const char *fname, void *dest, u32 width, u32 height);
 s32 sal_ImageDrawTiled(u16 *image, u32 width, u32 height, s32 xScroll, s32 yScroll, s32 x, s32 y);
 s32 sal_ImageDraw(u16 *image, u32 width, u32 height, s32 x, s32 y);
+s32 sal_HighlightBar(s32 width, s32 height, s32 x, s32 y);
 
 #endif /* __SAL_COMMON_H__ */


### PR DESCRIPTION
This commit implements an alpha-blended selection bar using a dithered-gradient algorithm that uses error propagation to achieve a good gradient in low-precision colour spaces.
