### PR TITLE
Fixed some GCC warnings and errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.o
+PocketSNES
 PocketSNES.opk
 .opk_data

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 *.o
-PocketSNES
 PocketSNES.opk
 .opk_data

--- a/Makefile.osx_lib
+++ b/Makefile.osx_lib
@@ -1,0 +1,73 @@
+
+# Define the applications properties here:
+
+TARGET = PocketSNES.dylib
+
+CC  := $(CROSS_COMPILE)clang --analyze
+CXX := $(CROSS_COMPILE)clang++ --analyze
+STRIP := $(CROSS_COMPILE)strip
+
+SYSROOT := $(shell $(CC) --print-sysroot)
+SDL_CFLAGS := `sdl-config --cflags`
+SDL_LIBS := `sdl-config --libs`
+
+ifdef V
+	CMD:=
+	SUM:=@\#
+else
+	CMD:=@
+	SUM:=@echo
+endif
+
+INCLUDE = -I pocketsnes \
+		-I sal/linux/include -I sal/include \
+		-I pocketsnes/include \
+		-I menu -I pocketsnes/linux -I pocketsnes/snes9x
+
+CFLAGS = $(INCLUDE) -DRC_OPTIMIZED -D__LINUX__ -D__DINGUX__ \
+		 -g -O3 -pipe -ffast-math $(SDL_CFLAGS) \
+		 -flto
+
+CXXFLAGS = $(CFLAGS) -fno-exceptions -fno-rtti
+
+LDFLAGS = -dynamiclib $(CXXFLAGS) -lpthread -lz -lpng -lm -lgcc $(SDL_LIBS)
+
+# Find all source files
+SOURCE = pocketsnes/snes9x menu sal/linux sal
+SRC_CPP = $(foreach dir, $(SOURCE), $(wildcard $(dir)/*.cpp))
+SRC_C   = $(foreach dir, $(SOURCE), $(wildcard $(dir)/*.c))
+OBJ_CPP = $(patsubst %.cpp, %.o, $(SRC_CPP))
+OBJ_C   = $(patsubst %.c, %.o, $(SRC_C))
+OBJS    = $(OBJ_CPP) $(OBJ_C)
+
+.PHONY : all
+all : $(TARGET)
+
+.PHONY: opk
+opk: $(TARGET).opk
+
+$(TARGET) : $(OBJS)
+	$(SUM) "  LD      $@"
+	$(CMD)$(CXX) $(CXXFLAGS) $^ -o $@ $(LDFLAGS)
+
+$(TARGET).opk: $(TARGET)
+	$(SUM) "  OPK     $@"
+	$(CMD)rm -rf .opk_data
+	$(CMD)cp -r data .opk_data
+	$(CMD)cp $< .opk_data/pocketsnes.gcw0
+	$(CMD)$(STRIP) .opk_data/pocketsnes.gcw0
+	$(CMD)mksquashfs .opk_data $@ -all-root -noappend -no-exports -no-xattrs -no-progress >/dev/null
+
+%.o: %.c
+	$(SUM) "  CC      $@"
+	$(CMD)$(CC) $(CFLAGS) -c $< -o $@
+
+%.o: %.cpp
+	$(SUM) "  CXX     $@"
+	$(CMD)$(CXX) $(CFLAGS) -c $< -o $@
+
+.PHONY : clean
+clean :
+	$(SUM) "  CLEAN   ."
+	$(CMD)rm -f $(OBJS) $(TARGET)
+	$(CMD)rm -rf .opk_data $(TARGET).opk

--- a/Makefile.osx_lib
+++ b/Makefile.osx_lib
@@ -3,8 +3,8 @@
 
 TARGET = PocketSNES.dylib
 
-CC  := $(CROSS_COMPILE)clang
-CXX := $(CROSS_COMPILE)clang++
+CC  := $(CROSS_COMPILE)gcc
+CXX := $(CROSS_COMPILE)g++
 STRIP := $(CROSS_COMPILE)strip
 
 SYSROOT := $(shell $(CC) --print-sysroot)

--- a/Makefile.osx_lib
+++ b/Makefile.osx_lib
@@ -3,8 +3,8 @@
 
 TARGET = PocketSNES.dylib
 
-CC  := $(CROSS_COMPILE)clang --analyze
-CXX := $(CROSS_COMPILE)clang++ --analyze
+CC  := $(CROSS_COMPILE)clang
+CXX := $(CROSS_COMPILE)clang++
 STRIP := $(CROSS_COMPILE)strip
 
 SYSROOT := $(shell $(CC) --print-sysroot)

--- a/pocketsnes/include/cpuaddr.h
+++ b/pocketsnes/include/cpuaddr.h
@@ -207,7 +207,7 @@ static void AbsoluteLong (AccessMode a, InternalOp op)
 #ifdef FAST_LSB_WORD_ACCESS
     Addr = (*(uint32 *) CPU.PC) & 0xffffff;
 #elif defined FAST_ALIGNED_LSB_WORD_ACCESS
-    if (((int) CPU.PC & 1) == 0)
+    if (((intptr_t) CPU.PC & 1) == 0)
         Addr = (*(uint16 *) CPU.PC) + (*(CPU.PC + 2) << 16);
     else
         Addr = *CPU.PC + ((*(uint16 *) (CPU.PC + 1)) << 8);
@@ -322,7 +322,7 @@ static void AbsoluteLongIndexedX (AccessMode a, InternalOp op)
 #ifdef FAST_LSB_WORD_ACCESS
     Addr = (*(uint32 *) CPU.PC + ICPU.Registers.X.W) & 0xffffff;
 #elif defined FAST_ALIGNED_LSB_WORD_ACCESS
-    if (((int) CPU.PC & 1) == 0)
+    if (((intptr_t) CPU.PC & 1) == 0)
         Addr = ((*(uint16 *) CPU.PC) + (*(CPU.PC + 2) << 16) + ICPU.Registers.X.W) & 0xFFFFFF;
     else
         Addr = (*CPU.PC + ((*(uint16 *) (CPU.PC + 1)) << 8) + ICPU.Registers.X.W) & 0xFFFFFF;

--- a/pocketsnes/include/font.h
+++ b/pocketsnes/include/font.h
@@ -86,7 +86,7 @@
   Super NES and Super Nintendo Entertainment System are trademarks of
   Nintendo Co., Limited and its subsidiary companies.
 *******************************************************************************/
-static char *font[] = {
+static const char *font[] = {
 "           .      . .                    .                ..       .      .                                                     ",
 "          .#.    .#.#.    . .     ...   .#. .     .      .##.     .#.    .#.     . .       .                                .   ",
 "          .#.    .#.#.   .#.#.   .###.  .#..#.   .#.     .#.     .#.      .#.   .#.#.     .#.                              .#.  ",

--- a/pocketsnes/include/getset.h
+++ b/pocketsnes/include/getset.h
@@ -120,7 +120,7 @@ static uint8 S9xGetByte (uint32 Address)
 		return (*(GetAddress + (Address & 0xffff)));
     }
 	
-    switch ((int) GetAddress)
+    switch ((intptr_t) GetAddress)
     {
     case CMemory::MAP_PPU:
 		return (S9xGetPPU (Address & 0xffff));
@@ -224,7 +224,7 @@ static uint16 S9xGetWord (uint32 Address)
 #endif	
     }
 
-    switch ((int) GetAddress)
+    switch ((intptr_t) GetAddress)
     {
     case CMemory::MAP_PPU:
 		return (S9xGetPPU (Address & 0xffff) |
@@ -347,7 +347,7 @@ static void S9xSetByte (uint8 Byte, uint32 Address)
 		return;
     }
 	
-    switch ((int) SetAddress)
+    switch ((intptr_t) SetAddress)
     {
     case CMemory::MAP_PPU:
 		S9xSetPPU (Byte, Address & 0xffff);
@@ -480,7 +480,7 @@ static void S9xSetWord (uint16 Word, uint32 Address)
 		return;
     }
 	
-    switch ((int) SetAddress)
+    switch ((intptr_t) SetAddress)
     {
     case CMemory::MAP_PPU:
 		S9xSetPPU ((uint8) Word, Address & 0xffff);
@@ -601,7 +601,7 @@ static uint8 *GetBasePointer (uint32 Address)
 	{
 		return s7r.bank50;
 	}
-    switch ((int) GetAddress)
+    switch ((intptr_t) GetAddress)
     {
 	case CMemory::MAP_SPC7110_DRAM:
 #ifdef SPC7110_DEBUG
@@ -667,7 +667,7 @@ static uint8 *S9xGetMemPointer (uint32 Address)
 	if(Settings.SPC7110&&((Address&0x7FFFFF)==0x4800))
 		return s7r.bank50;
 
-    switch ((int) GetAddress)
+    switch ((intptr_t) GetAddress)
     {
 	case CMemory::MAP_SPC7110_DRAM:
 #ifdef SPC7110_DEBUG
@@ -727,7 +727,7 @@ static void S9xSetPCBase (uint32 Address)
 		return;
     }
 	
-    switch ((int) GetAddress)
+    switch ((intptr_t) GetAddress)
     {
     case CMemory::MAP_PPU:
 		CPU.PCBase = Memory.FillRAM;

--- a/pocketsnes/snes9x/cheats.cpp
+++ b/pocketsnes/snes9x/cheats.cpp
@@ -155,8 +155,8 @@ const char *S9xGameGenieToRaw (const char *code, uint32 *address, uint8 *byte)
     strncpy (new_code + 2, code, 4);
     strcpy (new_code + 6, code + 5);
 
-    static char *real_hex  = "0123456789ABCDEF";
-    static char *genie_hex = "DF4709156BC8A23E";
+    static const char *real_hex  = "0123456789ABCDEF";
+    static const char *genie_hex = "DF4709156BC8A23E";
     
     for (int i = 2; i < 10; i++)
     {

--- a/pocketsnes/snes9x/fxdbg.cpp
+++ b/pocketsnes/snes9x/fxdbg.cpp
@@ -153,7 +153,7 @@ void FxPipeString(char * pvString)
     }
     /* Check for 'move' instruction */
     else if( PIPE >= 0x10 && PIPE <= 0x1f && TF(B) )
-	sprintf(p, "move r%d,r%d", USEX8(PIPE & 0x0f), GSU.pvSreg - GSU.avReg);
+	sprintf(p, "move r%d,r%d", (int)USEX8(PIPE & 0x0f), (int)(GSU.pvSreg - GSU.avReg));
     /* Check for 'ibt', 'lms' or 'sms' */
     else if( PIPE >= 0xa0 && PIPE <= 0xaf )
     {
@@ -165,7 +165,7 @@ void FxPipeString(char * pvString)
     }
     /* Check for 'moves' */
     else if( PIPE >= 0xb0 && PIPE <= 0xbf && TF(B) )
-	sprintf(p, "moves r%d,r%d", GSU.pvDreg - GSU.avReg, USEX8(PIPE & 0x0f) );
+	sprintf(p, "moves r%d,r%d", (int)(GSU.pvDreg - GSU.avReg), (int)USEX8(PIPE & 0x0f) );
     /* Check for 'iwt', 'lm' or 'sm' */
     else if( PIPE >= 0xf0 )
     {

--- a/pocketsnes/snes9x/sa1.cpp
+++ b/pocketsnes/snes9x/sa1.cpp
@@ -201,7 +201,7 @@ uint8 S9xSA1GetByte (uint32 address)
     if (GetAddress >= (uint8 *) CMemory::MAP_LAST)
 	return (*(GetAddress + (address & 0xffff)));
 
-    switch ((int) GetAddress)
+    switch ((intptr_t) GetAddress)
     {
     case CMemory::MAP_PPU:
 	return (S9xGetSA1 (address & 0xffff));
@@ -248,7 +248,7 @@ void S9xSA1SetByte (uint8 byte, uint32 address)
 	return;
     }
 
-    switch ((int) Setaddress)
+    switch ((intptr_t) Setaddress)
     {
     case CMemory::MAP_PPU:
 	S9xSetSA1 (byte, address & 0xffff);
@@ -310,7 +310,7 @@ void S9xSA1SetPCBase (uint32 address)
 	return;
     }
 
-    switch ((int) GetAddress)
+    switch ((intptr_t) GetAddress)
     {
     case CMemory::MAP_PPU:
 	SA1.PCBase = Memory.FillRAM - 0x2000;

--- a/pocketsnes/snes9x/snapshot.cpp
+++ b/pocketsnes/snes9x/snapshot.cpp
@@ -532,19 +532,19 @@ static FreezeData SnapS7RTC [] = {
 //static char ROMFilename [_MAX_PATH];
 //static char SnapshotFilename [_MAX_PATH];
 
-void FreezeStruct (STREAM stream, char *name, void *base, FreezeData *fields,
+void FreezeStruct (STREAM stream, const char *name, void *base, FreezeData *fields,
 				   int num_fields);
-void FreezeBlock (STREAM stream, char *name, uint8 *block, int size);
+void FreezeBlock (STREAM stream, const char *name, uint8 *block, int size);
 
-int UnfreezeStruct (STREAM stream, char *name, void *base, FreezeData *fields,
+int UnfreezeStruct (STREAM stream, const char *name, void *base, FreezeData *fields,
 					int num_fields);
-int UnfreezeBlock (STREAM stream, char *name, uint8 *block, int size);
+int UnfreezeBlock (STREAM stream, const char *name, uint8 *block, int size);
 
-int UnfreezeStructCopy (STREAM stream, char *name, uint8** block, FreezeData *fields, int num_fields);
+int UnfreezeStructCopy (STREAM stream, const char *name, uint8** block, FreezeData *fields, int num_fields);
 
 void UnfreezeStructFromCopy (void *base, FreezeData *fields, int num_fields, uint8* block);
 
-int UnfreezeBlockCopy (STREAM stream, char *name, uint8** block, int size);
+int UnfreezeBlockCopy (STREAM stream, const char *name, uint8** block, int size);
 
 bool8 Snapshot (const char *filename)
 {
@@ -659,7 +659,7 @@ void S9xFreezeToStream (STREAM stream)
     }
     sprintf (buffer, "%s:%04d\n", SNAPSHOT_MAGIC, SNAPSHOT_VERSION);
     WRITE_STREAM (buffer, strlen (buffer), stream);
-    sprintf (buffer, "NAM:%06d:%s%c", strlen (Memory.ROMFilename) + 1,
+    sprintf (buffer, "NAM:%06d:%s%c", (int)(strlen (Memory.ROMFilename) + 1),
 		Memory.ROMFilename, 0);
     WRITE_STREAM (buffer, strlen (buffer) + 1, stream);
     FreezeStruct (stream, "CPU", &CPU, SnapCPU, COUNT (SnapCPU));
@@ -977,7 +977,7 @@ int FreezeSize (int size, int type)
     }
 }
 
-void FreezeStruct (STREAM stream, char *name, void *base, FreezeData *fields,
+void FreezeStruct (STREAM stream, const char *name, void *base, FreezeData *fields,
 				   int num_fields)
 {
     // Work out the size of the required block
@@ -1065,7 +1065,7 @@ void FreezeStruct (STREAM stream, char *name, void *base, FreezeData *fields,
     delete[] block;
 }
 
-void FreezeBlock (STREAM stream, char *name, uint8 *block, int size)
+void FreezeBlock (STREAM stream, const char *name, uint8 *block, int size)
 {
     char buffer [512];
     sprintf (buffer, "%s:%06d:", name, size);
@@ -1074,7 +1074,7 @@ void FreezeBlock (STREAM stream, char *name, uint8 *block, int size)
     
 }
 
-int UnfreezeStruct (STREAM stream, char *name, void *base, FreezeData *fields,
+int UnfreezeStruct (STREAM stream, const char *name, void *base, FreezeData *fields,
 					int num_fields)
 {
     // Work out the size of the required block
@@ -1169,7 +1169,7 @@ int UnfreezeStruct (STREAM stream, char *name, void *base, FreezeData *fields,
     return (result);
 }
 
-int UnfreezeBlock (STREAM stream, char *name, uint8 *block, int size)
+int UnfreezeBlock (STREAM stream, const char *name, uint8 *block, int size)
 {
     char buffer [20];
     int len = 0;
@@ -1203,7 +1203,7 @@ int UnfreezeBlock (STREAM stream, char *name, uint8 *block, int size)
     return (SUCCESS);
 }
 
-int UnfreezeStructCopy (STREAM stream, char *name, uint8** block, FreezeData *fields, int num_fields)
+int UnfreezeStructCopy (STREAM stream, const char *name, uint8** block, FreezeData *fields, int num_fields)
 {
     // Work out the size of the required block
     int len = 0;
@@ -1292,7 +1292,7 @@ void UnfreezeStructFromCopy (void *base, FreezeData *fields, int num_fields, uin
     }
 }
 
-int UnfreezeBlockCopy (STREAM stream, char *name, uint8** block, int size)
+int UnfreezeBlockCopy (STREAM stream, const char *name, uint8** block, int size)
 {
     *block = new uint8 [size];
     int result;

--- a/pocketsnes/snes9x/spc700.cpp
+++ b/pocketsnes/snes9x/spc700.cpp
@@ -147,7 +147,7 @@ void STOP (char *s)
     buffer[0] = '\0';
 #endif
 
-    sprintf (String, "Sound CPU in unknown state executing %s at %04X\n%s\n", s, IAPU.PC - IAPU.RAM, buffer);
+    sprintf (String, "Sound CPU in unknown state executing %s at %04X\n%s\n", s, (int)(IAPU.PC - IAPU.RAM), buffer);
     S9xMessage (S9X_ERROR, S9X_APU_STOPPED, String);
     APU.TimerEnabled[0] = APU.TimerEnabled[1] = APU.TimerEnabled[2] = FALSE;
     IAPU.APUExecuting = FALSE;

--- a/pocketsnes/snes9x/spc7110.cpp
+++ b/pocketsnes/snes9x/spc7110.cpp
@@ -1658,7 +1658,7 @@ uint8* Get7110BasePtr(uint32 Address)
 //loads the index into memory.
 //index.bin is little-endian
 //format index (1)-table(3)-file offset(4)-length(4)
-bool Load7110Index(char* filename)
+bool Load7110Index(const char* filename)
 {
 	FILE* fp;
 	uint8 buffer[12];

--- a/sal/linux/sal_filesys.c
+++ b/sal/linux/sal_filesys.c
@@ -1,10 +1,11 @@
 
 #include <string.h>
-#include <error.h>
+//#include <error.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <dirent.h>
 #include "sal.h"
+
 
 s32 sal_DirectoryGetCurrent(s8 *path, u32 size)
 {
@@ -112,7 +113,12 @@ s32 sal_DirectoryGet(const char *path, struct SAL_DIRECTORY_ENTRY *dir,
 	s32 fileCount=0;
 	DIR *d;
 	struct dirent *de;
+	#ifdef __APPLE__
+	u_long entriesRead=0;
+	#else
 	ulong entriesRead=0;
+	#endif
+	
 	char fullFilename[256];
 	s32 endIndex=startIndex+count;
 	long loc;

--- a/sal/linux/sal_sound.c
+++ b/sal/linux/sal_sound.c
@@ -1,5 +1,5 @@
 #include <stdlib.h>
-#include <SDL.h>
+#include <SDL/SDL.h>
 
 #include <sal.h>
 

--- a/sal/sal_common.c
+++ b/sal/sal_common.c
@@ -928,7 +928,7 @@ s32 sal_ImageLoad(const char *fname, void *dest, u32 width, u32 height)
 
 	u32 h;
 	unsigned short *dst = dest;
-	if (info_ptr->pixel_depth != 24)
+	if (png_get_bit_depth(png_ptr, info_ptr) != 24)
 	{
 		sal_LastErrorSet("bg image not 24bpp");
 		png_destroy_read_struct(&png_ptr, info_ptr ? &info_ptr : NULL, (png_infopp)NULL);
@@ -936,7 +936,7 @@ s32 sal_ImageLoad(const char *fname, void *dest, u32 width, u32 height)
 		return SAL_ERROR;
 	}
 	
-	if (height != info_ptr->height)
+	if (height != png_get_image_height(png_ptr, info_ptr))
 	{
 		sal_LastErrorSet("image height invalid");
 		png_destroy_read_struct(&png_ptr, info_ptr ? &info_ptr : NULL, (png_infopp)NULL);
@@ -944,7 +944,7 @@ s32 sal_ImageLoad(const char *fname, void *dest, u32 width, u32 height)
 		return SAL_ERROR;
 	}
 	
-	if (width != info_ptr->width)
+	if (width != png_get_image_width(png_ptr, info_ptr))
 	{
 		sal_LastErrorSet("image width is invalid");
 		png_destroy_read_struct(&png_ptr, info_ptr ? &info_ptr : NULL, (png_infopp)NULL);


### PR DESCRIPTION
Fixed some GCC warnings
- related to string literals being used as char*
- related to cast u8\* to int without taking into account pointer size
