### PR TITLE
Added rom browser saving the last selected rom.

### DIFF
--- a/menu/menu.cpp
+++ b/menu/menu.cpp
@@ -108,10 +108,9 @@ s32 DeleteMenuOptions(const char *path, const char *filename,
 
 s32 LoadLastSelectedRomPos() // Try to get the last selected rom position from a config file
 {
-	char* home = getenv("HOME");
 	char lastselfile [128];
 	s32 savedval = ROM_SELECTOR_DEFAULT_FOCUS;
-	sprintf (lastselfile, "%s/.snes96_snapshots/lastselected.opt", home);
+	sprintf (lastselfile, "%s/lastselected.opt", sal_DirectoryGetHome());
 	FILE * pFile;
 	pFile = fopen (lastselfile,"r+");
 	if (pFile != NULL) {
@@ -123,9 +122,8 @@ s32 LoadLastSelectedRomPos() // Try to get the last selected rom position from a
 
 void SaveLastSelectedRomPos(s32 pospointer) // Save the last selected rom position in a config file
 {
-	char* home = getenv("HOME");
 	char lastselfile [128];
-	sprintf (lastselfile, "%s/.snes96_snapshots/lastselected.opt", home);
+	sprintf (lastselfile, "%s/lastselected.opt", sal_DirectoryGetHome());
 	FILE * pFile;
 	pFile = fopen (lastselfile,"w+");
 	fprintf (pFile, "%i", pospointer);
@@ -134,9 +132,8 @@ void SaveLastSelectedRomPos(s32 pospointer) // Save the last selected rom positi
 
 void DelLastSelectedRomPos() // Remove the last selected rom position config file
 {
-	char* home = getenv("HOME");
 	char lastselfile [128];
-	sprintf (lastselfile, "%s/.snes96_snapshots/lastselected.opt", home);
+	sprintf (lastselfile, "%s/lastselected.opt", sal_DirectoryGetHome());
 	remove (lastselfile);
 }
 

--- a/menu/menu.cpp
+++ b/menu/menu.cpp
@@ -106,6 +106,40 @@ s32 DeleteMenuOptions(const char *path, const char *filename,
 	return SAL_OK;
 }
 
+s32 LoadLastSelectedRomPos() // Try to get the last selected rom position from a config file
+{
+	char* home = getenv("HOME");
+	char lastselfile [128];
+	s32 savedval = ROM_SELECTOR_DEFAULT_FOCUS;
+	sprintf (lastselfile, "%s/.snes96_snapshots/lastselected.opt", home);
+	FILE * pFile;
+	pFile = fopen (lastselfile,"r+");
+	if (pFile != NULL) {
+		fscanf (pFile, "%i", &savedval);
+		fclose (pFile);
+	}
+	return savedval;
+}
+
+void SaveLastSelectedRomPos(s32 pospointer) // Save the last selected rom position in a config file
+{
+	char* home = getenv("HOME");
+	char lastselfile [128];
+	sprintf (lastselfile, "%s/.snes96_snapshots/lastselected.opt", home);
+	FILE * pFile;
+	pFile = fopen (lastselfile,"w+");
+	fprintf (pFile, "%i", pospointer);
+	fclose (pFile);
+}
+
+void DelLastSelectedRomPos() // Remove the last selected rom position config file
+{
+	char* home = getenv("HOME");
+	char lastselfile [128];
+	sprintf (lastselfile, "%s/.snes96_snapshots/lastselected.opt", home);
+	remove (lastselfile);
+}
+
 void MenuPause()
 {
 	sal_InputWaitForPress();
@@ -408,6 +442,8 @@ s32 FileSelect()
 			return 0;
 		}
 	}
+	
+	focus = LoadLastSelectedRomPos(); //try to load a saved position in the romlist
 
 	smooth=focus<<8;
 	sal_InputIgnore();
@@ -471,6 +507,7 @@ s32 FileSelect()
 			switch(focus)
 			{
 				case ROM_SELECTOR_SAVE_DEFAULT_DIR: //Save default directory
+					DelLastSelectedRomPos(); //delete any previously saved position in the romlist
 					SaveMenuOptions(mSystemDir, DEFAULT_ROM_DIR_FILENAME, DEFAULT_ROM_DIR_EXT, mRomDir, strlen(mRomDir), 1);
 					break;
 
@@ -519,6 +556,7 @@ s32 FileSelect()
 					else
 					{
 						// user has selected a rom, so load it
+						SaveLastSelectedRomPos(focus); // save the current position in the romlist
 						strcpy(mRomName, mRomDir);
 						sal_DirectoryCombine(mRomName,mRomList[focus].filename);
 						mQuickSavePresent=0;  // reset any quick saves

--- a/menu/menu.cpp
+++ b/menu/menu.cpp
@@ -108,9 +108,10 @@ s32 DeleteMenuOptions(const char *path, const char *filename,
 
 s32 LoadLastSelectedRomPos() // Try to get the last selected rom position from a config file
 {
-	char lastselfile [128];
+	char lastselfile[SAL_MAX_PATH];
 	s32 savedval = ROM_SELECTOR_DEFAULT_FOCUS;
-	sprintf (lastselfile, "%s/lastselected.opt", sal_DirectoryGetHome());
+	strcpy(lastselfile, sal_DirectoryGetHome());
+	sal_DirectoryCombine(lastselfile, "lastselected.opt");
 	FILE * pFile;
 	pFile = fopen (lastselfile,"r+");
 	if (pFile != NULL) {
@@ -122,8 +123,9 @@ s32 LoadLastSelectedRomPos() // Try to get the last selected rom position from a
 
 void SaveLastSelectedRomPos(s32 pospointer) // Save the last selected rom position in a config file
 {
-	char lastselfile [128];
-	sprintf (lastselfile, "%s/lastselected.opt", sal_DirectoryGetHome());
+	char lastselfile[SAL_MAX_PATH];
+	strcpy(lastselfile, sal_DirectoryGetHome());
+	sal_DirectoryCombine(lastselfile, "lastselected.opt");
 	FILE * pFile;
 	pFile = fopen (lastselfile,"w+");
 	fprintf (pFile, "%i", pospointer);
@@ -132,8 +134,9 @@ void SaveLastSelectedRomPos(s32 pospointer) // Save the last selected rom positi
 
 void DelLastSelectedRomPos() // Remove the last selected rom position config file
 {
-	char lastselfile [128];
-	sprintf (lastselfile, "%s/lastselected.opt", sal_DirectoryGetHome());
+	char lastselfile[SAL_MAX_PATH];
+	strcpy(lastselfile, sal_DirectoryGetHome());
+	sal_DirectoryCombine(lastselfile, "lastselected.opt");
 	remove (lastselfile);
 }
 


### PR DESCRIPTION
Each time a ROM is run, that position of the romlist is saved in a file.
When the ROM browser is launched, it loads the last rom position.
If a new default directory is saved, the rom position file is deleted.
